### PR TITLE
fix: adjust font size for account creation text in SignUpForm for responsive

### DIFF
--- a/src/features/auth/components/SignUpForm.tsx
+++ b/src/features/auth/components/SignUpForm.tsx
@@ -217,7 +217,7 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({
               {/* Logo and Text Create */}
               <div className="flex flex-col items-center">
                 <Image src="/assets/whalarora-logo.svg" alt="Logo" width={130} height={110} />
-                <p className="text-transparent bg-clip-text bg-white from-[#1F4293] to-[#43E9DD] text-[32px] font-bold">
+                <p className="text-transparent bg-clip-text bg-white from-[#1F4293] to-[#43E9DD] text-[28px] font-bold">
                   Create an account
                 </p>
               </div>


### PR DESCRIPTION


<!-- E.g  [WEB] implement-pull-request-template -->

##

### Related : JIRA []

<!-- Explain for detail this PR -->
Problem: "Create an account" text layout glitch when using responsive for mobile view

## Change Description
Fix: reduce text size 32px > 28px, now register page is viable on every device

## What kind of change ?

- [ ] New feature.
- [x] Bug fix.
- [ ] Code improvement.
- [ ] Service deployment.
- [ ] Release.
- [ ] FixDate.

## Is this a breaking change ?

- [ ] Yes
- [x] No

## Test Evidence

<!-- NOTE -->
